### PR TITLE
Fix autodiscovery hostname matching and multi-device IP address management

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -2,9 +2,10 @@ import Homey from 'homey';
 
 
 
-// Define an interface for global app settings, even if empty for now
+// Define an interface for global app settings
+// Note: ipAddress was removed as each device manages its own IP in device.store
 export interface AppSettings {
-    ipAddress?: string;
+    // Reserved for future global settings
 }
 
 class Quatt extends Homey.App {

--- a/drivers/quatt_heatpump/driver.ts
+++ b/drivers/quatt_heatpump/driver.ts
@@ -51,9 +51,6 @@ class QuattHeatpumpDriver extends Homey.Driver {
                 this.homey.app.log(`[Driver] ${this.id} - Manually pairing with IP address: ${ipAddress}`);
                 let hostname = await this.quattLocator.getQuattHostname(ipAddress);
 
-                // @ts-ignore updateSettings is an extension of the Quatt Homey App
-                this.homey.app.updateSettings({ipAddress: ipAddress});
-
                 this.devices = [
                     {
                         name: "Quatt CiC (manual)",
@@ -68,7 +65,7 @@ class QuattHeatpumpDriver extends Homey.Driver {
 
                 this.deviceError = false;
 
-                this.homey.app.log(`[Driver] ${this.id} - Successful manual connection with device:`, ipAddress);
+                this.homey.app.log(`[Driver] ${this.id} - Successfully paired with device at ${ipAddress}`);
                 await session.showView('list_devices');
             } catch (error) {
                 this.homey.app.error(`[Driver] ${this.id} - Error while manually pairing:`, JSON.stringify(error));


### PR DESCRIPTION
This PR addresses several critical issues with IP address management and device identification, especially in scenarios with multiple CiC devices and IP range migrations.

## Problems Fixed

1. **IP address timeout on settings change**
   - When manually entering a new IP address (e.g., 10.7.7.xxx), the app would timeout trying to connect to an old IP (192.168.xxx)
   - Fixed by using direct connection without triggering autodiscovery

2. **App-wide settings overwriting device IP**
   - Old IP addresses persisted in app-wide settings and overwrote correct device IPs during initialization
   - Fixed by removing app-wide ipAddress setting; each device now manages its own IP in device.store

3. **Multi-device conflicts**
   - With multiple CiC devices, app settings would be overwritten by the last initialized device
   - Fixed by using per-device storage only

4. **Incorrect subnet scanning**
   - Autodiscovery used stale app settings instead of Homey's current IP
   - Fixed by using getLocalAddress() with proper IP:port parsing

5. **CiC assignment during re-discovery**
   - implemented hostname matching to ensure each device always finds its specific CiC

## Changes

### app.ts
- Removed ipAddress from AppSettings interface
- Each device now manages its own IP independently

### drivers/quatt_heatpump/device.ts
- initDeviceSettings(): Removed app settings update, uses device store only
- onSettings(): Direct IP connection without autodiscovery trigger
- setIPAddress(): Removed app settings update
- discoverDeviceOnSubnets(): Uses getLocalAddress() and device's own subnet
- scanSubnetForDevice(): Added hostname verification using findQuattByHostname()
- New method: setCapabilityValuesWithoutAutodiscovery()
- New method: updateAllCapabilities() (refactored for code reuse)

### drivers/quatt_heatpump/driver.ts
- manual_pair(): Removed app settings update

### lib/quatt/locator.ts
- New method: findQuattByHostname() - Scans entire subnet and matches specific CiC by hostname, ensuring correct device identification in multi-device setups

## Benefits

- ✅ Full multi-device support (multiple CiCs can coexist)
- ✅ IP range migrations work correctly (no stale IPs)
- ✅ Manual IP changes work without unwanted autodiscovery
- ✅ Safe autodiscovery with hostname matching
- ✅ No automation mix-ups in multi-device scenarios
- ✅ Better logging for debugging

## Testing Scenarios

1. Single CiC device: Works as before
2. Multiple CiC devices: Each maintains its own IP correctly
3. IP range migration: No persistence of old addresses
4. Manual IP change: Direct connection without scanning
5. Autodiscovery: Always finds correct CiC by hostname

🤖 Generated with [Claude Code](https://claude.com/claude-code)