### PR TITLE
bug(api): fix device connection by sharing remote API credentials

### DIFF
--- a/drivers/quatt_chill/device.ts
+++ b/drivers/quatt_chill/device.ts
@@ -1,5 +1,5 @@
 import Homey from 'homey';
-import {QuattChill, QuattRemoteApiClient, QuattTokens} from '../../lib/quatt';
+import {QuattChill, QuattRemoteApiClient, QuattTokenStore, QuattTokens} from '../../lib/quatt';
 
 interface QuattChillDeviceSettings {
     updateInterval: number;
@@ -17,20 +17,39 @@ class QuattChillDevice extends Homey.Device {
         this.log('Initialization device: Quatt Chill');
 
         this.chillUuid = this.getStoreValue('chillUuid') as string | null;
-        const remoteTokens = this.getStoreValue('remoteTokens') as QuattTokens | undefined;
         const remoteCicId = this.getStoreValue('remoteCicId') as string | undefined;
-        const remoteInstallationId = this.getStoreValue('remoteInstallationId') as string | undefined;
 
-        if (!this.chillUuid || !remoteTokens || !remoteCicId || !remoteInstallationId) {
-            await this.setUnavailable('Quatt Chill is nog niet gekoppeld. Voeg hem opnieuw toe vanuit een Quatt met Remote Control.').catch(this.error);
+        // Credentials come from the shared store rather than this device's own copy, so that
+        // repairing the CiC also restores every Chill instead of stranding them on tokens for
+        // an identity that no longer exists.
+        const tokenStore = new QuattTokenStore(this.homey.settings, this.log.bind(this));
+        let credentials = remoteCicId ? tokenStore.getCredentials(remoteCicId) : null;
+
+        if (!credentials && remoteCicId) {
+            // Migrate from the CiC's store in preference to our own: "Repair" only ever wrote to
+            // the CiC, so a Chill's own copy may be older. Falling back to our own copy still
+            // covers the case where the CiC device was removed.
+            const source = this.findCicStoreValues(remoteCicId) ?? {
+                remoteTokens: this.getStoreValue('remoteTokens') as QuattTokens | undefined,
+                remoteInstallationId: this.getStoreValue('remoteInstallationId') as string | undefined,
+            };
+
+            if (source.remoteTokens && source.remoteInstallationId) {
+                credentials = tokenStore.migrateFromDevice(remoteCicId, source.remoteTokens, source.remoteInstallationId);
+            }
+        }
+
+        if (!this.chillUuid || !credentials) {
+            await this.setUnavailable(this.homey.__('device.chill.notLinked')).catch(this.error);
             return;
         }
 
         this.remoteClient = new QuattRemoteApiClient(
             this.homey.app.manifest.version,
-            remoteTokens,
-            remoteCicId,
-            remoteInstallationId
+            credentials.tokens,
+            credentials.cicId,
+            credentials.installationId,
+            tokenStore.sourceFor(credentials.cicId)
         );
 
         await this.migrateCapabilities();
@@ -41,6 +60,34 @@ class QuattChillDevice extends Homey.Device {
         const settings = this.getSettings() as QuattChillDeviceSettings;
         const updateInterval = typeof settings.updateInterval === 'number' ? settings.updateInterval : 30;
         this.setCapabilityValuesInterval(updateInterval);
+    }
+
+    /**
+     * Find the paired CiC device that owns the given CiC id, so its stored credentials can be
+     * used as the migration source.
+     */
+    private findCicStoreValues(cicId: string): { remoteTokens?: QuattTokens; remoteInstallationId?: string } | null {
+        try {
+            const heatpumpDriver = this.homey.drivers.getDriver('quatt_heatpump');
+            const heatpumpDevices = heatpumpDriver ? heatpumpDriver.getDevices() : [];
+
+            for (const heatpumpDevice of heatpumpDevices) {
+                const device = heatpumpDevice as Homey.Device;
+                if (device.getStoreValue('remoteCicId') !== cicId) {
+                    continue;
+                }
+
+                const remoteTokens = device.getStoreValue('remoteTokens') as QuattTokens | undefined;
+                const remoteInstallationId = device.getStoreValue('remoteInstallationId') as string | undefined;
+                if (remoteTokens && remoteInstallationId) {
+                    return {remoteTokens, remoteInstallationId};
+                }
+            }
+        } catch (error) {
+            this.log('Unable to read credentials from the paired Quatt CiC:', error);
+        }
+
+        return null;
     }
 
     async onDeleted() {
@@ -196,7 +243,6 @@ class QuattChillDevice extends Homey.Device {
         }
 
         const ok = await this.remoteClient.updateChillAction(this.chillUuid, action);
-        await this.persistRefreshedTokens();
         if (!ok) {
             throw new Error(errorMessage);
         }
@@ -207,7 +253,6 @@ class QuattChillDevice extends Homey.Device {
 
         try {
             const chills = await this.remoteClient.getChills();
-            await this.persistRefreshedTokens();
             const currentChill = chills.find((chill) => chill.uuid === this.chillUuid);
 
             if (!currentChill) {
@@ -241,13 +286,6 @@ class QuattChillDevice extends Homey.Device {
         } catch (error) {
             this.log('Unable to update Chill capabilities:', error);
             await this.setUnavailable(error instanceof Error ? error.message : String(error)).catch(this.error);
-        }
-    }
-
-    private async persistRefreshedTokens() {
-        const tokens = this.remoteClient?.getTokens();
-        if (tokens) {
-            await this.setStoreValue('remoteTokens', tokens).catch(this.error);
         }
     }
 

--- a/drivers/quatt_chill/driver.ts
+++ b/drivers/quatt_chill/driver.ts
@@ -1,5 +1,5 @@
 import Homey from 'homey';
-import {QuattRemoteApiClient, QuattTokens} from '../../lib/quatt';
+import {QuattRemoteApiClient, QuattTokenStore, QuattTokens} from '../../lib/quatt';
 
 class QuattChillDriver extends Homey.Driver {
     async onInit() {
@@ -17,22 +17,34 @@ class QuattChillDriver extends Homey.Driver {
         const heatpumpDevices = heatpumpDriver ? heatpumpDriver.getDevices() : [];
         const results: any[] = [];
 
+        const tokenStore = new QuattTokenStore(this.homey.settings, this.log.bind(this));
+
         for (const heatpumpDevice of heatpumpDevices) {
             const device = heatpumpDevice as Homey.Device;
-            const remoteTokens = device.getStoreValue('remoteTokens') as QuattTokens | undefined;
             const remoteCicId = device.getStoreValue('remoteCicId') as string | undefined;
-            const remoteInstallationId = device.getStoreValue('remoteInstallationId') as string | undefined;
 
-            if (!remoteTokens || !remoteCicId || !remoteInstallationId) {
+            if (!remoteCicId) {
                 continue;
+            }
+
+            let credentials = tokenStore.getCredentials(remoteCicId);
+
+            if (!credentials) {
+                const remoteTokens = device.getStoreValue('remoteTokens') as QuattTokens | undefined;
+                const remoteInstallationId = device.getStoreValue('remoteInstallationId') as string | undefined;
+                if (!remoteTokens || !remoteInstallationId) {
+                    continue;
+                }
+                credentials = tokenStore.migrateFromDevice(remoteCicId, remoteTokens, remoteInstallationId);
             }
 
             try {
                 const remoteClient = new QuattRemoteApiClient(
                     this.homey.app.manifest.version,
-                    remoteTokens,
-                    remoteCicId,
-                    remoteInstallationId
+                    credentials.tokens,
+                    credentials.cicId,
+                    credentials.installationId,
+                    tokenStore.sourceFor(credentials.cicId)
                 );
                 const chills = await remoteClient.getChills();
 
@@ -42,14 +54,15 @@ class QuattChillDriver extends Homey.Driver {
                         data: {
                             id: chill.uuid,
                             uuid: chill.uuid,
-                            cicId: remoteCicId,
-                            installationId: remoteInstallationId,
+                            cicId: credentials.cicId,
+                            installationId: credentials.installationId,
                         },
+                        // Only the CiC reference is stored; the credentials themselves stay in
+                        // the shared store so a Repair on the CiC keeps this device working.
                         store: {
                             chillUuid: chill.uuid,
-                            remoteTokens,
-                            remoteCicId,
-                            remoteInstallationId,
+                            remoteCicId: credentials.cicId,
+                            remoteInstallationId: credentials.installationId,
                         },
                     });
                 }

--- a/drivers/quatt_heatpump/device.ts
+++ b/drivers/quatt_heatpump/device.ts
@@ -1,5 +1,5 @@
 import Homey, {FlowCardTrigger} from 'homey';
-import {QuattClient, QuattRemoteApiClient, QuattTokens} from "../../lib/quatt";
+import {QuattClient, QuattRemoteApiClient, QuattTokenStore, QuattTokens} from "../../lib/quatt";
 import {CicHeatpump, CicStats} from "../../lib/quatt/cic-stats";
 import {QuattApiError} from "../../lib/quatt/errors"; // DeviceUnavailableError was unused
 import {QuattLocator} from "../../lib/quatt/locator";
@@ -86,17 +86,27 @@ class QuattHeatpump extends Homey.Device {
         this.quattClient = new QuattClient(this.homey.app.manifest.version, deviceAddress);
 
         // Initialize remote API client if tokens are available
-        const remoteTokens = this.getStoreValue("remoteTokens") as QuattTokens | undefined;
+        const tokenStore = new QuattTokenStore(this.homey.settings, this.log.bind(this));
         const remoteCicId = this.getStoreValue("remoteCicId") as string | undefined;
-        const remoteInstallationId = this.getStoreValue("remoteInstallationId") as string | undefined;
+        let credentials = remoteCicId ? tokenStore.getCredentials(remoteCicId) : null;
 
-        if (remoteTokens && remoteCicId && remoteInstallationId) {
+        if (!credentials && remoteCicId) {
+            // Pre-1.9.1 installations kept their own copy of the credentials in device.store.
+            const remoteTokens = this.getStoreValue("remoteTokens") as QuattTokens | undefined;
+            const remoteInstallationId = this.getStoreValue("remoteInstallationId") as string | undefined;
+            if (remoteTokens && remoteInstallationId) {
+                credentials = tokenStore.migrateFromDevice(remoteCicId, remoteTokens, remoteInstallationId);
+            }
+        }
+
+        if (credentials) {
             this.log('Initializing remote API client');
             this.remoteClient = new QuattRemoteApiClient(
                 this.homey.app.manifest.version,
-                remoteTokens,
-                remoteCicId,
-                remoteInstallationId
+                credentials.tokens,
+                credentials.cicId,
+                credentials.installationId,
+                tokenStore.sourceFor(credentials.cicId)
             );
 
             // Update settings to show remote is configured (if not already set)
@@ -518,12 +528,6 @@ class QuattHeatpump extends Homey.Device {
 
                 this.log(`[Action] Successfully set day sound level to ${args.level}`);
 
-                // Update stored tokens in case they were refreshed
-                const tokens = this.remoteClient.getTokens();
-                if (tokens) {
-                    await this.setStoreValue('remoteTokens', tokens);
-                }
-
                 return true;
             } catch (error) {
                 this.error('[Action] Error setting day sound level:', error);
@@ -550,12 +554,6 @@ class QuattHeatpump extends Homey.Device {
                 }
 
                 this.log(`[Action] Successfully set night sound level to ${args.level}`);
-
-                // Update stored tokens in case they were refreshed
-                const tokens = this.remoteClient.getTokens();
-                if (tokens) {
-                    await this.setStoreValue('remoteTokens', tokens);
-                }
 
                 return true;
             } catch (error) {
@@ -584,12 +582,6 @@ class QuattHeatpump extends Homey.Device {
                 }
 
                 this.log(`[Action] Successfully set pricing limit to ${enabled}`);
-
-                // Update stored tokens in case they were refreshed
-                const tokens = this.remoteClient.getTokens();
-                if (tokens) {
-                    await this.setStoreValue('remoteTokens', tokens);
-                }
 
                 return true;
             } catch (error) {

--- a/drivers/quatt_heatpump/driver.ts
+++ b/drivers/quatt_heatpump/driver.ts
@@ -147,6 +147,9 @@ class QuattHeatpumpDriver extends Homey.Driver {
                 // Keep the CiC reference so the device knows which credentials are its own.
                 await device.setStoreValue('remoteInstallationId', result.installationId);
                 await device.setStoreValue('remoteCicId', cicId);
+                // Also kept in the device store so that downgrading to a version without the
+                // shared store leaves the CiC with usable credentials.
+                await device.setStoreValue('remoteTokens', result.tokens);
 
                 // Update settings to show remote control is configured
                 await device.setSettings({

--- a/drivers/quatt_heatpump/driver.ts
+++ b/drivers/quatt_heatpump/driver.ts
@@ -1,7 +1,7 @@
 import Homey from 'homey';
 import PairSession from "homey/lib/PairSession";
 import {QuattLocator} from "../../lib/quatt/locator";
-import {QuattRemoteApiClient, QuattTokens} from "../../lib/quatt";
+import {QuattRemoteApiClient, QuattTokenStore, QuattTokens} from "../../lib/quatt";
 
 class QuattHeatpumpDriver extends Homey.Driver {
     private type: string = '';
@@ -134,8 +134,17 @@ class QuattHeatpumpDriver extends Homey.Driver {
 
                 this.homey.app.log(`[Driver] ${this.id} - Repair: Successfully authenticated and paired with remote API`);
 
-                // Store the remote data in device
-                await device.setStoreValue('remoteTokens', result.tokens);
+                // Credentials are shared by the CiC and every Chill on this installation, so they
+                // go into app-level storage. Writing them here is what makes "Repair" heal the
+                // Chill devices too instead of only the CiC.
+                const tokenStore = new QuattTokenStore(this.homey.settings, this.homey.app.log.bind(this.homey.app));
+                tokenStore.saveCredentials({
+                    cicId,
+                    installationId: result.installationId,
+                    tokens: result.tokens,
+                });
+
+                // Keep the CiC reference so the device knows which credentials are its own.
                 await device.setStoreValue('remoteInstallationId', result.installationId);
                 await device.setStoreValue('remoteCicId', cicId);
 
@@ -144,8 +153,15 @@ class QuattHeatpumpDriver extends Homey.Driver {
                     remoteControlStatus: `✓ Configured (${firstName} ${lastName})`
                 });
 
-                // Initialize the remote client on the device immediately
-                device.remoteClient = remoteClient;
+                // Initialize the remote client on the device immediately. Rebuild it against the
+                // shared store so it refreshes through the same lock as every other device.
+                device.remoteClient = new QuattRemoteApiClient(
+                    this.homey.app.manifest.version,
+                    result.tokens,
+                    cicId,
+                    result.installationId,
+                    tokenStore.sourceFor(cicId)
+                );
 
                 this.homey.app.log(`[Driver] ${this.id} - Repair: Remote data stored and remote client initialized`);
 

--- a/lib/quatt/index.ts
+++ b/lib/quatt/index.ts
@@ -3,6 +3,7 @@ import {RestClient} from "typed-rest-client/RestClient";
 import { QuattApiError } from './errors';
 
 export { QuattRemoteApiClient, QuattTokens, QuattRemoteSettings, QuattChill, QuattChillAction, QuattChillFanMode, QuattChillMode } from './remote-api';
+export { QuattTokenStore, QuattCredentials, QuattTokenSource, REMOTE_CREDENTIALS_SETTINGS_KEY } from './token-store';
 
 type OptionalCicStats = CicStats | null;
 

--- a/lib/quatt/remote-api.spec.ts
+++ b/lib/quatt/remote-api.spec.ts
@@ -1,0 +1,201 @@
+import {RestClient} from 'typed-rest-client/RestClient';
+import {QuattRemoteApiClient, QuattTokens} from './remote-api';
+import {QuattTokenStore, QuattSettingsStorage} from './token-store';
+
+jest.mock('typed-rest-client/RestClient');
+
+const MockedRestClient = RestClient as jest.MockedClass<typeof RestClient>;
+
+const mockGet = jest.fn();
+const mockCreate = jest.fn();
+const mockReplace = jest.fn();
+
+MockedRestClient.mockImplementation(() => ({
+  get: mockGet,
+  create: mockCreate,
+  replace: mockReplace,
+} as unknown as RestClient));
+
+class FakeSettings implements QuattSettingsStorage {
+  private values: Record<string, any> = {};
+
+  get(key: string): any {
+    return this.values[key];
+  }
+
+  set(key: string, value: any): void {
+    this.values[key] = value;
+  }
+}
+
+/** Mimics typed-rest-client, which rejects with an Error carrying a statusCode. */
+const httpError = (statusCode: number): Error => {
+  const error = new Error(`Failed request: (${statusCode})`);
+  (error as any).statusCode = statusCode;
+  return error;
+};
+
+const refreshResponse = (idToken: string) => ({
+  statusCode: 200,
+  result: {
+    id_token: idToken,
+    refresh_token: 'refresh-token',
+    expires_in: '3600',
+  },
+});
+
+const chillsResponse = {
+  statusCode: 200,
+  result: {chills: [{uuid: 'chill-1', name: 'Quatt Chill'}]},
+};
+
+const validTokens = (): QuattTokens => ({
+  idToken: 'valid-id-token',
+  refreshToken: 'refresh-token',
+  expiresAt: Date.now() + 3_600_000,
+});
+
+const expiredTokens = (): QuattTokens => ({
+  idToken: 'expired-id-token',
+  refreshToken: 'refresh-token',
+  expiresAt: Date.now() - 1_000,
+});
+
+const authHeaderOf = (call: any[]): string => call[call.length - 1].additionalHeaders.Authorization;
+
+describe('QuattRemoteApiClient', () => {
+  let settings: FakeSettings;
+  let store: QuattTokenStore;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    settings = new FakeSettings();
+    store = new QuattTokenStore(settings);
+  });
+
+  const clientFor = (cicId: string, tokens: QuattTokens) => {
+    store.saveCredentials({cicId, installationId: 'inst-1', tokens});
+    return new QuattRemoteApiClient('1.0.0', tokens, cicId, 'inst-1', store.sourceFor(cicId));
+  };
+
+  describe('recovering from a rejected token', () => {
+    it('refreshes and retries once when the API answers 401', async () => {
+      const client = clientFor('CIC-1', validTokens());
+
+      // The token has not expired locally, but the server rejects it anyway.
+      mockGet
+        .mockRejectedValueOnce(httpError(401))
+        .mockResolvedValueOnce(chillsResponse);
+      mockCreate.mockResolvedValueOnce(refreshResponse('recovered-id-token'));
+
+      await expect(client.getChills()).resolves.toEqual([{uuid: 'chill-1', name: 'Quatt Chill'}]);
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(mockGet).toHaveBeenCalledTimes(2);
+      expect(authHeaderOf(mockGet.mock.calls[0])).toBe('Bearer valid-id-token');
+      expect(authHeaderOf(mockGet.mock.calls[1])).toBe('Bearer recovered-id-token');
+    });
+
+    it('persists the recovered token so other devices pick it up', async () => {
+      const client = clientFor('CIC-1', validTokens());
+
+      mockGet
+        .mockRejectedValueOnce(httpError(401))
+        .mockResolvedValueOnce(chillsResponse);
+      mockCreate.mockResolvedValueOnce(refreshResponse('recovered-id-token'));
+
+      await client.getChills();
+
+      expect(store.getCredentials('CIC-1')?.tokens.idToken).toBe('recovered-id-token');
+    });
+
+    it('retries a rejected write as well', async () => {
+      const client = clientFor('CIC-1', validTokens());
+
+      mockReplace
+        .mockRejectedValueOnce(httpError(401))
+        .mockResolvedValueOnce({statusCode: 200, result: {}});
+      mockCreate.mockResolvedValueOnce(refreshResponse('recovered-id-token'));
+
+      await expect(client.updateCicSettings({dayMaxSoundLevel: '45'})).resolves.toBe(true);
+      expect(mockReplace).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives up after one retry rather than looping', async () => {
+      const client = clientFor('CIC-1', validTokens());
+
+      mockGet.mockRejectedValue(httpError(401));
+      mockCreate.mockResolvedValueOnce(refreshResponse('still-rejected'));
+
+      await expect(client.getChills()).rejects.toThrow();
+      expect(mockGet).toHaveBeenCalledTimes(2);
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not refresh on errors that are not auth failures', async () => {
+      const client = clientFor('CIC-1', validTokens());
+
+      mockGet.mockRejectedValue(httpError(500));
+
+      await expect(client.getChills()).rejects.toThrow();
+      expect(mockCreate).not.toHaveBeenCalled();
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sharing credentials between devices', () => {
+    it('refreshes only once when two devices act concurrently', async () => {
+      const cic = clientFor('CIC-1', expiredTokens());
+      const chill = new QuattRemoteApiClient('1.0.0', expiredTokens(), 'CIC-1', 'inst-1', store.sourceFor('CIC-1'));
+
+      mockCreate.mockResolvedValue(refreshResponse('single-refresh'));
+      mockGet.mockResolvedValue(chillsResponse);
+
+      await Promise.all([cic.getChills(), chill.getChills()]);
+
+      // Both clients needed a refresh, but the shared lock collapses it into one call.
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(authHeaderOf(mockGet.mock.calls[0])).toBe('Bearer single-refresh');
+      expect(authHeaderOf(mockGet.mock.calls[1])).toBe('Bearer single-refresh');
+    });
+
+    it('adopts a token refreshed by another device without refreshing again', async () => {
+      const chill = clientFor('CIC-1', expiredTokens());
+
+      // The CiC device refreshed in the meantime and wrote the result to the shared store.
+      store.updateTokens('CIC-1', {
+        idToken: 'refreshed-elsewhere',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 3_600_000,
+      });
+      mockGet.mockResolvedValue(chillsResponse);
+
+      await chill.getChills();
+
+      expect(mockCreate).not.toHaveBeenCalled();
+      expect(authHeaderOf(mockGet.mock.calls[0])).toBe('Bearer refreshed-elsewhere');
+    });
+
+    it('picks up an installation id changed by a repair', async () => {
+      const chill = clientFor('CIC-1', validTokens());
+
+      store.saveCredentials({cicId: 'CIC-1', installationId: 'inst-after-repair', tokens: validTokens()});
+      mockGet.mockResolvedValue(chillsResponse);
+
+      await chill.getChills();
+
+      expect(mockGet.mock.calls[0][0]).toContain('/me/installation/inst-after-repair/devices/chills');
+    });
+
+    it('still works without a shared store, for the pairing flow', async () => {
+      const client = new QuattRemoteApiClient('1.0.0', expiredTokens(), 'CIC-1', 'inst-1');
+
+      mockCreate.mockResolvedValueOnce(refreshResponse('standalone-refresh'));
+      mockGet.mockResolvedValue(chillsResponse);
+
+      await client.getChills();
+
+      expect(authHeaderOf(mockGet.mock.calls[0])).toBe('Bearer standalone-refresh');
+    });
+  });
+});

--- a/lib/quatt/remote-api.ts
+++ b/lib/quatt/remote-api.ts
@@ -1,5 +1,6 @@
 import {RestClient, IRestResponse} from "typed-rest-client/RestClient";
 import { QuattApiError } from './errors';
+import { QuattTokenSource } from './token-store';
 
 // Firebase Configuration
 const FIREBASE_API_KEY = "AIzaSyDM4PIXYDS9x53WUj-tDjOVAb6xKgzxX9Y";
@@ -94,8 +95,9 @@ export class QuattRemoteApiClient {
     private tokens: QuattTokens | null = null;
     private cicId: string | null = null;
     private installationId: string | null = null;
+    private tokenSource: QuattTokenSource | null = null;
 
-    constructor(appVersion: string, tokens?: QuattTokens, cicId?: string, installationId?: string) {
+    constructor(appVersion: string, tokens?: QuattTokens, cicId?: string, installationId?: string, tokenSource?: QuattTokenSource) {
         this.appVersion = appVersion;
         this.client = new RestClient(`Homey Quatt App/${this.appVersion}`);
         if (tokens) {
@@ -106,6 +108,11 @@ export class QuattRemoteApiClient {
         }
         if (installationId) {
             this.installationId = installationId;
+        }
+        if (tokenSource) {
+            this.tokenSource = tokenSource;
+            // Prefer whatever the shared store already holds over the snapshot we were constructed with.
+            this.tokens = tokenSource.getTokens() ?? this.tokens;
         }
     }
 
@@ -171,43 +178,26 @@ export class QuattRemoteApiClient {
      * Update CIC settings (sound levels, pricing limits)
      */
     async updateCicSettings(settings: QuattRemoteSettings): Promise<boolean> {
-        if (!this.tokens || !this.cicId) {
+        if (!this.cicId) {
             throw new QuattApiError('Not authenticated or CIC not paired');
         }
 
-        // Refresh token if expired
-        if (Date.now() >= this.tokens.expiresAt) {
-            await this._refreshToken();
-        }
-
         try {
-            const response = await this.client.replace<any>(
+            const response = await this._authorizedRequest<any>((idToken) => this.client.replace<any>(
                 `${QUATT_API_BASE_URL}/me/cic/${this.cicId}`,
                 settings,
                 {
                     additionalHeaders: {
-                        'Authorization': `Bearer ${this.tokens.idToken}`,
+                        'Authorization': `Bearer ${idToken}`,
                         'Content-Type': 'application/json'
                     }
                 }
-            );
+            ));
 
             return response.statusCode === 200;
         } catch (error) {
-            // If token refresh fails, try one more time
-            if (error instanceof Error && error.message.includes('401')) {
-                await this._refreshToken();
-                const response = await this.client.replace<any>(
-                    `${QUATT_API_BASE_URL}/me/cic/${this.cicId}`,
-                    settings,
-                    {
-                        additionalHeaders: {
-                            'Authorization': `Bearer ${this.tokens!.idToken}`,
-                            'Content-Type': 'application/json'
-                        }
-                    }
-                );
-                return response.statusCode === 200;
+            if (error instanceof QuattApiError) {
+                throw error;
             }
             throw new QuattApiError(`Failed to update settings: ${error}`);
         }
@@ -217,23 +207,18 @@ export class QuattRemoteApiClient {
      * Get current CIC data from remote API
      */
     async getCicData(): Promise<any> {
-        if (!this.tokens || !this.cicId) {
+        if (!this.cicId) {
             throw new QuattApiError('Not authenticated or CIC not paired');
         }
 
-        // Refresh token if expired
-        if (Date.now() >= this.tokens.expiresAt) {
-            await this._refreshToken();
-        }
-
-        const response = await this.client.get<any>(
+        const response = await this._authorizedRequest<any>((idToken) => this.client.get<any>(
             `${QUATT_API_BASE_URL}/me/cic/${this.cicId}`,
             {
                 additionalHeaders: {
-                    'Authorization': `Bearer ${this.tokens.idToken}`
+                    'Authorization': `Bearer ${idToken}`
                 }
             }
-        );
+        ));
 
         if (response.statusCode !== 200) {
             throw new QuattApiError(`Failed to get CIC data: Status ${response.statusCode}`);
@@ -244,6 +229,9 @@ export class QuattRemoteApiClient {
 
 
     private async _ensureAuthenticated(): Promise<void> {
+        // Another device sharing these credentials may have refreshed them since our last call.
+        this._syncTokensFromSource();
+
         if (!this.tokens) {
             throw new QuattApiError('Not authenticated');
         }
@@ -251,6 +239,54 @@ export class QuattRemoteApiClient {
         if (Date.now() >= this.tokens.expiresAt) {
             await this._refreshToken();
         }
+    }
+
+    private _syncTokensFromSource(): void {
+        if (!this.tokenSource) {
+            return;
+        }
+
+        const shared = this.tokenSource.getTokens();
+        if (shared) {
+            this.tokens = shared;
+        }
+
+        const installationId = this.tokenSource.getInstallationId();
+        if (installationId) {
+            this.installationId = installationId;
+        }
+    }
+
+    /**
+     * Run an authenticated request, refreshing the token up front when it is known to be
+     * expired and once more if the API rejects it anyway.
+     *
+     * The retry matters because expiry is only tracked locally: after a re-pair the previous
+     * identity is gone server-side while our stored expiresAt still looks valid, so without
+     * this the device would 401 forever and never recover.
+     */
+    private async _authorizedRequest<T>(request: (idToken: string) => Promise<IRestResponse<T>>): Promise<IRestResponse<T>> {
+        await this._ensureAuthenticated();
+
+        try {
+            return await request(this.tokens!.idToken);
+        } catch (error) {
+            if (!QuattRemoteApiClient._isUnauthorized(error)) {
+                throw error;
+            }
+
+            await this._refreshToken(true);
+            return await request(this.tokens!.idToken);
+        }
+    }
+
+    /**
+     * typed-rest-client rejects any response over 299 with an Error carrying a statusCode
+     * property, so the status has to be read from there rather than from a response object.
+     */
+    private static _isUnauthorized(error: unknown): boolean {
+        const statusCode = (error as { statusCode?: number } | null)?.statusCode;
+        return statusCode === 401 || statusCode === 403;
     }
 
     /**
@@ -261,16 +297,14 @@ export class QuattRemoteApiClient {
             throw new QuattApiError('No installation ID available');
         }
 
-        await this._ensureAuthenticated();
-
-        const response = await this.client.get<any>(
+        const response = await this._authorizedRequest<any>((idToken) => this.client.get<any>(
             `${QUATT_API_BASE_URL}/me/installation/${this.installationId}/devices/chills`,
             {
                 additionalHeaders: {
-                    'Authorization': `Bearer ${this.tokens!.idToken}`
+                    'Authorization': `Bearer ${idToken}`
                 }
             }
-        );
+        ));
 
         if (response.statusCode !== 200 || !response.result) {
             throw new QuattApiError(`Failed to get Quatt Chill devices: Status ${response.statusCode}`);
@@ -292,18 +326,16 @@ export class QuattRemoteApiClient {
             throw new QuattApiError('No installation ID available');
         }
 
-        await this._ensureAuthenticated();
-
-        const response = await this.client.create<any>(
+        const response = await this._authorizedRequest<any>((idToken) => this.client.create<any>(
             `${QUATT_API_BASE_URL}/me/installation/${this.installationId}/devices/chills/${chillUuid}/actions`,
             action,
             {
                 additionalHeaders: {
-                    'Authorization': `Bearer ${this.tokens!.idToken}`,
+                    'Authorization': `Bearer ${idToken}`,
                     'Content-Type': 'application/json'
                 }
             }
-        );
+        ));
 
         return response.statusCode === 200 || response.statusCode === 201 || response.statusCode === 204;
     }
@@ -555,16 +587,43 @@ export class QuattRemoteApiClient {
         };
     }
 
-    private async _refreshToken(): Promise<void> {
+    /**
+     * @param force refresh even when the current token has not expired locally, used after
+     *              the API rejected it.
+     */
+    private async _refreshToken(force: boolean = false): Promise<void> {
         if (!this.tokens) {
             throw new QuattApiError('No tokens to refresh');
         }
 
+        if (!this.tokenSource) {
+            this.tokens = await this._requestFreshTokens(this.tokens);
+            return;
+        }
+
+        // Serialise refreshes so that the CiC and every Chill do not each burn the same
+        // refresh token concurrently and then persist conflicting results.
+        await this.tokenSource.runExclusive(async () => {
+            const shared = this.tokenSource!.getTokens() ?? this.tokens!;
+
+            // Somebody else may have refreshed while we waited for the lock.
+            if (!force && Date.now() < shared.expiresAt) {
+                this.tokens = shared;
+                return;
+            }
+
+            const refreshed = await this._requestFreshTokens(shared);
+            this.tokens = refreshed;
+            this.tokenSource!.setTokens(refreshed);
+        });
+    }
+
+    private async _requestFreshTokens(current: QuattTokens): Promise<QuattTokens> {
         const response = await this.client.create<FirebaseTokenRefreshResponse>(
             `${FIREBASE_TOKEN_URL}?key=${FIREBASE_API_KEY}`,
             {
                 grant_type: 'refresh_token',
-                refresh_token: this.tokens.refreshToken
+                refresh_token: current.refreshToken
             }
         );
 
@@ -572,7 +631,7 @@ export class QuattRemoteApiClient {
             throw new QuattApiError('Failed to refresh token');
         }
 
-        this.tokens = {
+        return {
             idToken: response.result.id_token,
             refreshToken: response.result.refresh_token,
             expiresAt: Date.now() + (parseInt(response.result.expires_in) * 1000)

--- a/lib/quatt/token-store.spec.ts
+++ b/lib/quatt/token-store.spec.ts
@@ -1,0 +1,176 @@
+import {QuattTokenStore, QuattSettingsStorage, REMOTE_CREDENTIALS_SETTINGS_KEY} from './token-store';
+import {QuattTokens} from './remote-api';
+
+/**
+ * In-memory stand-in for Homey's ManagerSettings.
+ */
+class FakeSettings implements QuattSettingsStorage {
+  private values: Record<string, any> = {};
+
+  get(key: string): any {
+    return this.values[key];
+  }
+
+  set(key: string, value: any): void {
+    this.values[key] = value;
+  }
+}
+
+const tokensAt = (expiresAt: number, idToken = 'id-token'): QuattTokens => ({
+  idToken,
+  refreshToken: 'refresh-token',
+  expiresAt,
+});
+
+describe('QuattTokenStore', () => {
+  let settings: FakeSettings;
+  let store: QuattTokenStore;
+
+  beforeEach(() => {
+    settings = new FakeSettings();
+    store = new QuattTokenStore(settings);
+  });
+
+  describe('credential storage', () => {
+    it('returns null when no credentials are stored for a CiC', () => {
+      expect(store.getCredentials('CIC-unknown')).toBeNull();
+    });
+
+    it('round-trips credentials through settings', () => {
+      store.saveCredentials({cicId: 'CIC-1', installationId: 'inst-1', tokens: tokensAt(1000)});
+
+      expect(store.getCredentials('CIC-1')).toEqual({
+        cicId: 'CIC-1',
+        installationId: 'inst-1',
+        tokens: tokensAt(1000),
+      });
+    });
+
+    it('keeps credentials for multiple CiCs side by side', () => {
+      store.saveCredentials({cicId: 'CIC-1', installationId: 'inst-1', tokens: tokensAt(1000, 'a')});
+      store.saveCredentials({cicId: 'CIC-2', installationId: 'inst-2', tokens: tokensAt(2000, 'b')});
+
+      expect(store.getCredentials('CIC-1')?.tokens.idToken).toBe('a');
+      expect(store.getCredentials('CIC-2')?.tokens.idToken).toBe('b');
+    });
+
+    it('writes under a single settings key', () => {
+      store.saveCredentials({cicId: 'CIC-1', installationId: 'inst-1', tokens: tokensAt(1000)});
+
+      expect(Object.keys(settings.get(REMOTE_CREDENTIALS_SETTINGS_KEY))).toEqual(['CIC-1']);
+    });
+
+    it('ignores malformed stored data instead of throwing', () => {
+      settings.set(REMOTE_CREDENTIALS_SETTINGS_KEY, 'not-an-object');
+
+      expect(store.getCredentials('CIC-1')).toBeNull();
+    });
+
+    it('treats credentials without tokens as absent', () => {
+      settings.set(REMOTE_CREDENTIALS_SETTINGS_KEY, {'CIC-1': {cicId: 'CIC-1'}});
+
+      expect(store.getCredentials('CIC-1')).toBeNull();
+    });
+  });
+
+  describe('updateTokens', () => {
+    it('replaces only the tokens, keeping the installation id', () => {
+      store.saveCredentials({cicId: 'CIC-1', installationId: 'inst-1', tokens: tokensAt(1000, 'old')});
+
+      store.updateTokens('CIC-1', tokensAt(5000, 'new'));
+
+      expect(store.getCredentials('CIC-1')).toEqual({
+        cicId: 'CIC-1',
+        installationId: 'inst-1',
+        tokens: tokensAt(5000, 'new'),
+      });
+    });
+
+    it('does nothing when the CiC is unknown', () => {
+      store.updateTokens('CIC-unknown', tokensAt(5000));
+
+      expect(store.getCredentials('CIC-unknown')).toBeNull();
+    });
+  });
+
+  describe('migrateFromDevice', () => {
+    it('seeds the shared store from per-device credentials', () => {
+      const migrated = store.migrateFromDevice('CIC-1', tokensAt(1000, 'from-device'), 'inst-1');
+
+      expect(migrated.tokens.idToken).toBe('from-device');
+      expect(store.getCredentials('CIC-1')?.installationId).toBe('inst-1');
+    });
+
+    it('does not overwrite credentials that are already shared', () => {
+      store.saveCredentials({cicId: 'CIC-1', installationId: 'inst-new', tokens: tokensAt(9000, 'current')});
+
+      // A stale device store must not clobber the credentials a Repair just wrote.
+      const migrated = store.migrateFromDevice('CIC-1', tokensAt(1000, 'stale'), 'inst-old');
+
+      expect(migrated.tokens.idToken).toBe('current');
+      expect(store.getCredentials('CIC-1')?.installationId).toBe('inst-new');
+    });
+  });
+
+  describe('sourceFor', () => {
+    it('gives every device the same view of the credentials', () => {
+      store.saveCredentials({cicId: 'CIC-1', installationId: 'inst-1', tokens: tokensAt(1000, 'shared')});
+
+      const cicSource = store.sourceFor('CIC-1');
+      const chillSource = store.sourceFor('CIC-1');
+
+      expect(chillSource.getTokens()?.idToken).toBe('shared');
+
+      // A refresh performed by the CiC must be visible to the Chill.
+      cicSource.setTokens(tokensAt(2000, 'refreshed'));
+
+      expect(chillSource.getTokens()?.idToken).toBe('refreshed');
+    });
+
+    it('serialises concurrent work for the same CiC', async () => {
+      const source = store.sourceFor('CIC-1');
+      const order: string[] = [];
+
+      const task = (name: string) => source.runExclusive(async () => {
+        order.push(`${name}-start`);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        order.push(`${name}-end`);
+      });
+
+      await Promise.all([task('a'), task('b')]);
+
+      // Never interleaved: the second caller waits for the first to finish.
+      expect(order).toEqual(['a-start', 'a-end', 'b-start', 'b-end']);
+    });
+
+    it('lets a later caller run after an earlier one fails', async () => {
+      const source = store.sourceFor('CIC-1');
+
+      const failing = source.runExclusive(async () => {
+        throw new Error('refresh failed');
+      });
+
+      await expect(failing).rejects.toThrow('refresh failed');
+      await expect(source.runExclusive(async () => 'recovered')).resolves.toBe('recovered');
+    });
+
+    it('does not block work for a different CiC', async () => {
+      let releaseFirst: () => void = () => undefined;
+      const blocked = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+
+      const first = store.sourceFor('CIC-1').runExclusive(async () => {
+        await blocked;
+        return 'first';
+      });
+      const second = store.sourceFor('CIC-2').runExclusive(async () => 'second');
+
+      // CIC-2 completes while CIC-1 is still held.
+      await expect(second).resolves.toBe('second');
+
+      releaseFirst();
+      await expect(first).resolves.toBe('first');
+    });
+  });
+});

--- a/lib/quatt/token-store.ts
+++ b/lib/quatt/token-store.ts
@@ -1,0 +1,142 @@
+import {QuattTokens} from "./remote-api";
+
+/**
+ * The subset of Homey's ManagerSettings that we depend on, so the store can be
+ * unit tested without a Homey runtime.
+ */
+export interface QuattSettingsStorage {
+    get(key: string): any;
+
+    set(key: string, value: any): void;
+}
+
+export interface QuattCredentials {
+    tokens: QuattTokens;
+    cicId: string;
+    installationId: string;
+}
+
+/**
+ * Credentials are shared by every device that talks to the Quatt remote API, so they
+ * live in app-level settings rather than in each device's own store.
+ */
+export const REMOTE_CREDENTIALS_SETTINGS_KEY = 'remoteCredentials';
+
+/**
+ * A token source scoped to a single CiC, handed to a QuattRemoteApiClient.
+ */
+export interface QuattTokenSource {
+    getTokens(): QuattTokens | null;
+
+    /**
+     * A re-pair can hand out a different installation, so clients re-read it rather than
+     * holding on to the value they were constructed with.
+     */
+    getInstallationId(): string | null;
+
+    setTokens(tokens: QuattTokens): void;
+
+    /**
+     * Run fn while holding the refresh lock for this CiC, so that concurrent refreshes
+     * across devices are serialised instead of racing each other.
+     */
+    runExclusive<T>(fn: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * Single source of truth for Quatt remote API credentials.
+ *
+ * Previously the CiC device and every Chill device each kept their own copy of the same
+ * tokens in device.store and refreshed them independently. That meant a re-pair ("Repair")
+ * only updated the CiC, leaving every Chill stranded on credentials for an identity that no
+ * longer existed, and concurrent refreshes could overwrite each other's state.
+ */
+export class QuattTokenStore {
+    private readonly settings: QuattSettingsStorage;
+    private readonly logger: (...args: any[]) => void;
+    private readonly refreshLocks = new Map<string, Promise<unknown>>();
+
+    constructor(settings: QuattSettingsStorage, logger: (...args: any[]) => void = () => {
+    }) {
+        this.settings = settings;
+        this.logger = logger;
+    }
+
+    private readAll(): Record<string, QuattCredentials> {
+        const raw = this.settings.get(REMOTE_CREDENTIALS_SETTINGS_KEY);
+        if (!raw || typeof raw !== 'object') {
+            return {};
+        }
+        return raw as Record<string, QuattCredentials>;
+    }
+
+    getCredentials(cicId: string): QuattCredentials | null {
+        const credentials = this.readAll()[cicId];
+        if (!credentials || !credentials.tokens || !credentials.installationId) {
+            return null;
+        }
+        return credentials;
+    }
+
+    saveCredentials(credentials: QuattCredentials): void {
+        const all = this.readAll();
+        all[credentials.cicId] = credentials;
+        this.settings.set(REMOTE_CREDENTIALS_SETTINGS_KEY, all);
+        this.logger(`[QuattTokenStore] Stored credentials for CiC ${credentials.cicId}`);
+    }
+
+    updateTokens(cicId: string, tokens: QuattTokens): void {
+        const existing = this.getCredentials(cicId);
+        if (!existing) {
+            this.logger(`[QuattTokenStore] Cannot update tokens, no credentials for CiC ${cicId}`);
+            return;
+        }
+        this.saveCredentials({...existing, tokens});
+    }
+
+    /**
+     * Seed the shared store from credentials that still live in a device's own store,
+     * so existing installations keep working after updating the app. Does not overwrite
+     * credentials that are already shared.
+     */
+    migrateFromDevice(cicId: string, tokens: QuattTokens, installationId: string): QuattCredentials {
+        const existing = this.getCredentials(cicId);
+        if (existing) {
+            return existing;
+        }
+
+        const credentials: QuattCredentials = {cicId, installationId, tokens};
+        this.saveCredentials(credentials);
+        this.logger(`[QuattTokenStore] Migrated per-device credentials for CiC ${cicId} into shared storage`);
+        return credentials;
+    }
+
+    /**
+     * A token source bound to one CiC. All sources for the same CiC share this store's
+     * settings and refresh lock, so every device sees the same tokens.
+     */
+    sourceFor(cicId: string): QuattTokenSource {
+        return {
+            getTokens: () => this.getCredentials(cicId)?.tokens ?? null,
+            getInstallationId: () => this.getCredentials(cicId)?.installationId ?? null,
+            setTokens: (tokens: QuattTokens) => this.updateTokens(cicId, tokens),
+            runExclusive: <T>(fn: () => Promise<T>) => this.runExclusive(cicId, fn),
+        };
+    }
+
+    private async runExclusive<T>(cicId: string, fn: () => Promise<T>): Promise<T> {
+        const previous = this.refreshLocks.get(cicId) ?? Promise.resolve();
+        // A failed refresh must not poison the queue for whoever comes next.
+        const current = previous.then(() => fn(), () => fn());
+        const guard = current.then(() => undefined, () => undefined);
+        this.refreshLocks.set(cicId, guard);
+
+        try {
+            return await current;
+        } finally {
+            if (this.refreshLocks.get(cicId) === guard) {
+                this.refreshLocks.delete(cicId);
+            }
+        }
+    }
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -22,5 +22,10 @@
     "ipChangeSuspected": "Suspected IP address change. Please check device settings if it remains unavailable.",
     "unableToConnectToDeviceWithManualIP": "Unable to connect to Quatt CiC at IP address __ipAddress__. Trying auto-discovery.",
     "unableToAutoDiscoverQuattCiC": "Unable to auto-discover Quatt CiC. Please ensure it is powered on and connected to the same network as your Homey."
+  },
+  "device": {
+    "chill": {
+      "notLinked": "Quatt Chill is not linked yet. Add it again from a Quatt with Remote Control enabled."
+    }
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -22,5 +22,10 @@
     "ipChangeSuspected": "Mogelijke IP-adres wijziging. Controleer de apparaatinstellingen als het apparaat onbeschikbaar blijft.",
     "unableToConnectToDeviceWithManualIP": "Kan geen verbinding maken met Quatt CiC op IP-adres __ipAddress__. Automatische detectie wordt geprobeerd.",
     "unableToAutoDiscoverQuattCiC": "Kan Quatt CiC niet automatisch ontdekken. Zorg ervoor dat het apparaat is ingeschakeld en verbonden is met hetzelfde netwerk als je Homey."
+  },
+  "device": {
+    "chill": {
+      "notLinked": "Quatt Chill is nog niet gekoppeld. Voeg hem opnieuw toe vanuit een Quatt met Remote Control."
+    }
   }
 }


### PR DESCRIPTION
## Problem

Every device that talks to the Quatt remote API kept **its own copy** of the same credentials in `device.store`, and refreshed them independently:

- `drivers/quatt_chill/driver.ts` copied `remoteTokens` out of the CiC device into each Chill's store at pair time — a snapshot.
- `drivers/quatt_chill/device.ts` and `drivers/quatt_heatpump/device.ts` each wrote refreshed tokens back to their **own** store.
- The Repair flow (`drivers/quatt_heatpump/driver.ts`) mints a brand-new anonymous Firebase identity and wrote it **only to the CiC device**.

Two consequences:

1. **Repair could not heal a Chill.** After a Repair the CiC had a new identity while every Chill still held tokens for the old one. Nothing ever propagated, so the only fix was removing and re-adding each Chill.
2. **Devices raced each other.** N clients independently refreshing one credential set, each persisting to a different place, leaves N divergent auth states for a single account.

While tracing this I found a second defect that makes the first one permanent:

3. **The 401 retry never fired.** `updateCicSettings` caught errors and checked `error.message.includes('401')`. `typed-rest-client` rejects anything over HTTP 299 with an `Error` whose *message* is the API's error body (falling back to `"Failed request: (401)"` only when the body is empty) and attaches the real status as `err.statusCode`. So the retry only triggered when the API happened to return no error body. The other three authenticated calls — `getCicData`, `getChills`, `updateChillAction` — had no retry at all.

Token expiry is only ever checked against the locally stored `expiresAt`. Once an `idToken` is rejected server-side while `expiresAt` still looks valid — exactly what a re-pair causes — the code never refreshed, threw, and the device went `setUnavailable` **permanently**.

## Fix

- New `lib/quatt/token-store.ts`. Credentials live once in app-level settings keyed by CiC id. `sourceFor(cicId)` hands a `QuattTokenSource` to each client, so all devices read and write the same tokens, and `runExclusive` serialises refreshes per CiC so concurrent refreshes collapse into one.
- `QuattRemoteApiClient` takes an optional token source. It re-reads tokens (and the installation id, which a re-pair can change) before each call, and all four authenticated calls now go through `_authorizedRequest`, which refreshes and retries **once** on 401/403 — read from `err.statusCode`, not the message.
- Repair writes to the shared store, so it now restores the CiC *and* every Chill.
- Chill devices no longer store credentials at all, only the `remoteCicId` reference.

### Migration

Existing installations are seeded from `device.store` on first init. A Chill prefers the **CiC's** copy over its own — the CiC's is the one Repair updated, and device init order isn't guaranteed, so a Chill initialising first must not seed the shared store with a stale snapshot.

## Testing

`npm run build` and `npm test` pass — 38 tests, up from 15.

New `lib/quatt/token-store.spec.ts` (14) covers storage, multi-CiC isolation, migration precedence, and the refresh lock. New `lib/quatt/remote-api.spec.ts` (8) pins the behaviour that was broken:

- 401 → refresh → retry, for both reads and writes
- the recovered token is persisted for other devices
- retries exactly once rather than looping; non-auth errors don't trigger a refresh
- two devices refreshing concurrently produce **one** HTTP refresh
- a client adopts a token refreshed by another device instead of refreshing again
- a changed installation id is picked up after a repair

`npm run lint` is unchanged from `main` (20 pre-existing errors, all `Parsing error: The keyword 'interface' is reserved` — ESLint has no TypeScript parser configured here; the new file adds a 21st of the same kind).

### Screenshot 

Homey error right after CIC repair

![Screenshot_20260804_155357_Homey.jpg](https://github.com/user-attachments/assets/aa92fd80-121b-4da8-838b-09dd24d12995)

Can confirm this works by running the app locally on `development` mode through the Homey CLI.

<img width="414" height="1077" alt="image" src="https://github.com/user-attachments/assets/33589e1b-2071-4702-9552-0551cbc5b710" />


